### PR TITLE
Fix closing anchor tag

### DIFF
--- a/404-federalist-client.html
+++ b/404-federalist-client.html
@@ -39,7 +39,7 @@
                 <span id="title">404 / Page not found</span>
             </h1>
             <p>
-                You might want to double-check your link and try again, or return to the <a href="/">homepage<a/>.
+                You might want to double-check your link and try again, or return to the <a href="/">homepage</a>.
             </p>
             <p id="federalist-explanation">
                 This is a default 404 page for <a href='https://federalist.18f.gov'>Federalist</a>, a hosting service for federal websites.


### PR DESCRIPTION
This pull request fixes a markup error that exists in the default Federalist 404 page. 

Example 404 page: https://design.login.gov/404

Errors, via https://validator.w3.org/nu/#textarea:

![image](https://user-images.githubusercontent.com/1779930/150189237-96780f52-1bd4-47af-aaca-1cdc2d78f119.png)
