### PR TITLE
rename to pages

### DIFF
--- a/404-pages-client.html
+++ b/404-pages-client.html
@@ -21,7 +21,7 @@
                 padding-bottom: 2px;
                 border-bottom: 3px solid #205493;
             }
-            #federalist-explanation {
+            #pages-explanation {
                 font-style: italic;
             }
             body {
@@ -41,11 +41,11 @@
             <p>
                 You might want to double-check your link and try again, or return to the <a href="/">homepage</a>.
             </p>
-            <p id="federalist-explanation">
-                This is a default 404 page for <a href='https://federalist.18f.gov'>Federalist</a>, a hosting service for federal websites.
+            <p id="pages-explanation">
+                This is a default 404 page for <a href='https://cloud.gov/pages'>Pages</a>, a hosting service for federal websites.
             </p>
             <svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                <title>Federalist logo (quill inside circle)</title>
+                <title>Pages logo (quill inside circle)</title>
                 <desc>Created with Sketch.</desc>
                 <defs></defs>
                 <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-## Federalist 404 page
+## Pages 404 page
 
 ### About
 
-[Federalist](https://github.com/18F/federalist) helps federal agencies and offices quickly launch compliant websites.
+[Cloud.gov Pages](https://github.com/cloud-gov/pages-core) helps federal agencies and offices quickly launch compliant websites.
 
-This is the 404 error page for Federalist *client sites*, as opposed to the Federalist web app itself.
+This is the 404 error page for Pages *client sites*, as opposed to the Pages web app itself.
 
 ### Deployment
 
-To deploy, copy the 404-federalist-client.html to your S3 bucket root 404.html
+To deploy, copy the 404-pages-client.html to your S3 bucket root 404.html
 ```
-aws s3 cp 404-federalist-client.html s3://[BUCKET]/404.html
+aws s3 cp 404-pages-client.html s3://[BUCKET]/404.html
 ```


### PR DESCRIPTION
## Changes proposed in this pull request:
- rename to pages

## Security considerations
Will potentially break pages builds during the transition if the file is not found (in conjunction with [a corresponding pages-build-container PR](https://github.com/cloud-gov/pages-build-container/pull/375))
